### PR TITLE
 #150589791: Make the API endpoints RESTful

### DIFF
--- a/.meteor/packages
+++ b/.meteor/packages
@@ -95,3 +95,4 @@ practicalmeteor:sinon
 
 
 # Custom Packages
+simple:rest

--- a/.meteor/packages
+++ b/.meteor/packages
@@ -95,4 +95,4 @@ practicalmeteor:sinon
 
 
 # Custom Packages
-simple:rest
+nimble:restivus

--- a/.meteor/versions
+++ b/.meteor/versions
@@ -117,6 +117,7 @@ mongo@1.1.14
 mongo-id@1.0.6
 mongo-livedata@1.0.12
 mrt:later@1.6.1
+nimble:restivus@0.8.11
 npm-bcrypt@0.9.2
 npm-mongo@2.2.11_2
 oauth@1.1.12
@@ -147,7 +148,6 @@ session@1.1.7
 sha@1.0.9
 shell-server@0.2.1
 simple:json-routes@2.1.0
-simple:rest@1.1.1
 spacebars@1.0.13
 spacebars-compiler@1.0.13
 srp@1.0.10

--- a/.meteor/versions
+++ b/.meteor/versions
@@ -146,6 +146,8 @@ service-configuration@1.0.11
 session@1.1.7
 sha@1.0.9
 shell-server@0.2.1
+simple:json-routes@2.1.0
+simple:rest@1.1.1
 spacebars@1.0.13
 spacebars-compiler@1.0.13
 srp@1.0.10

--- a/server/startup/index.js
+++ b/server/startup/index.js
@@ -4,6 +4,7 @@ import Load from "./load-data";
 import Packages from "./packages";
 import Registry from "./registry";
 import Init from "./init";
+import ApiRoutes from "./restful-api-endpoints";
 
 export default function () {
   Accounts();
@@ -12,4 +13,5 @@ export default function () {
   Packages();
   Registry();
   Init();
+  ApiRoutes();
 }

--- a/server/startup/restful-api-endpoints.js
+++ b/server/startup/restful-api-endpoints.js
@@ -1,0 +1,123 @@
+import { Shops, Products, Orders, Cart, Inventory, Emails, Accounts } from "/lib/collections";
+import Reaction  from "/server/api/core";
+
+const hasPermission = (user, role) => {
+  return user.roles[Reaction.getShopId()].includes(role);
+};
+
+export default () => {
+  // Global API configuration
+  const Api = new Restivus({
+    useDefaultAuth: true,
+    prettyJson: true,
+    defaultHeaders: {
+      "Content-Type": "application/json"
+    },
+    version: "v1"
+  });
+
+  const getApiOptions = (collectionName) => {
+    return {
+      routeOptions: {
+        authRequired: true
+      },
+
+      endpoints: {
+        // GET all items in collection
+        get: {
+          action() {
+            if (hasPermission(this.user, "admin") ||
+            hasPermission(this.user, "guest") ||
+            hasPermission(this.user, "owner")) {
+              const allRecords = collectionName.findOne(this.urlParams.id);
+              if (!allRecords) {
+                return { status: "fail",
+                  message: "An error occurred. Record does not exist" };
+              }
+              return { statusCode: 200, status: "success", data: allRecords };
+            }
+          }
+        },
+
+        // POST into a collection
+        post: {
+          action() {
+            if (!(hasPermission(this.user, "admin") ||
+            hasPermission(this.user, "owner"))) {
+              return { statusCode: 403, status: "fail",
+                message: "You do not have permission to add a record" };
+            }
+            if (hasPermission(this.user, "admin") ||
+            hasPermission(this.user, "owner")) {
+              const isInserted = collectionName.insert(this.bodyParams);
+              if (isInserted) {
+                return { statusCode: 201, status: "success", data: isInserted };
+              } return { statusCode: 400, status: "fail",
+                message: "An error occurred. Post was not successful" };
+            }
+          }
+        },
+
+        // UPDATE a collection
+        put: {
+          action() {
+            if (!(hasPermission(this.user, "admin") ||
+            hasPermission(this.user, "owner"))) {
+              return { statusCode: 403, status: "fail",
+                message: "You do not have permission to edit this record" };
+            }
+            if (hasPermission(this.user, "admin") ||
+            hasPermission(this.user, "owner")) {
+              const isUpdated = collectionName.upsert({ _id: this.urlParams.id }, {
+                $set: this.bodyParams
+              });
+              if (!isUpdated) {
+                return { status: "fail", statusCode: 404,
+                  message: "An error occurred. Record does not exist" };
+              }
+              const record = collectionName.findOne(this.urlParams.id);
+              return { statusCode: 200, status: "success", data: isUpdated, record };
+            }
+          }
+        },
+
+        // DELETE a record in a collection
+        delete: {
+          action() {
+            if (!(hasPermission(this.user, "admin") ||
+            hasPermission(this.user, "owner"))) {
+              return { statusCode: 403, status: "fail",
+                message: "You do not have permission to delete this record" };
+            }
+            if (hasPermission(this.user, "admin") ||
+            hasPermission(this.user, "owner")) {
+              // we delete a product by setting the isDeleted flag
+              if (collectionName._name === "Products") {
+                // get collection from db
+                const collection = collectionName.findOne(this.urlParams.id);
+                // modify isDeleted flag
+                collection.isDeleted = true;
+                // update collection in db
+                const isDeleted = collectionName.upsert({ _id: this.urlParams.id }, {
+                  $set: collection
+                });
+                return { data: isDeleted, message: "product has been archived" };
+                // other collections may be removed
+              }
+              const isDeleted = collectionName.remove({ _id: this.urlParams.id });
+              return { status: "success", data: isDeleted,  message: "record is deleted" };
+            }
+          }
+        }
+      }
+    };
+  };
+
+  Api.addCollection(Shops, getApiOptions(Shops));
+  Api.addCollection(Products, getApiOptions(Products));
+  Api.addCollection(Orders, getApiOptions(Orders));
+  Api.addCollection(Cart, getApiOptions(Cart));
+  Api.addCollection(Inventory, getApiOptions(Inventory));
+  Api.addCollection(Emails, getApiOptions(Emails));
+  Api.addCollection(Accounts, getApiOptions(Accounts));
+};


### PR DESCRIPTION
#### What does this PR do?
- Makes the API endpoints for Reaction commerce RESTful

#### How should this be manually tested?
- The endpoints can be tested out on postman or web browser
#### Any background context you want to provide?
- `simple:rest` was installed to handle conversion of endpoints making it RESTful.
#### What are the relevant pivotal tracker stories?
- Make the API endpoints RESTful
#### Screenshots (if appropriate)
- Screenshots are shown below:

<img width="1277" alt="orders" src="https://user-images.githubusercontent.com/11311182/30271407-104ea156-96e8-11e7-9980-764c6379a3db.png">

<img width="1277" alt="products" src="https://user-images.githubusercontent.com/11311182/30271448-3bc0420e-96e8-11e7-9092-1e545a73d408.png">
<img width="1280" alt="shops" src="https://user-images.githubusercontent.com/11311182/30271492-6619b198-96e8-11e7-9494-8a0993c6a181.png">




